### PR TITLE
Disable building functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "README.md",
   "private": true,
   "scripts": {
-    "build": "yarn images:zip && yarn images:sizes && yarn build:vuepress && yarn build:functions",
+    "build": "yarn images:zip && yarn images:sizes && yarn build:vuepress",
     "build:vuepress": "vuepress build && cp ./.vuepress/dist/assets/js/admin.*.js ./.vuepress/dist/assets/js/admin.js && cp -r .non-vuepress-public/* .vuepress/dist/",
     "build:functions": "cd ./.vuepress/functions/gosrc && make build",
     "images:compress": "node ./.build/imageCompressor.js",


### PR DESCRIPTION
Functions appear to be halting our deploy, I believe deploying updates to be more important than the functions (which I believe to be a play one with cats and two ones that are forum related)